### PR TITLE
add handling of different lengths of scalarTags and correct Usage in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Tested on TensorFlow version 0.11.0, 1.1.0 and 1.3.0 and Python 2.7 and 3.6.
 ## Usage
 
 ```
-python readLogs.py <output-folder> <output-path-to-csv> <summaries>
+python readLogs.py <input-path-to-logfile> <output-folder> <summaries>
 
 Inputs:
    <input-path-to-logfile>  - Path to TensorFlow logfile.

--- a/exportTensorFlowLog.py
+++ b/exportTensorFlowLog.py
@@ -172,8 +172,12 @@ if ('scalars' in summaries):
 				data = [v.wall_time, v.step];
 				for s in scalarTags:
 					scalarTag = ea.Scalars(s);
-					S = scalarTag[i];
-					data.append(S.value);
+					if i < len(scalarTag):
+						S = scalarTag[i];
+						data.append(S.value);
+					else:
+						print("ScalarTag {} is too short - writing NaN".format(s))
+						data.append(math.nan)
 				logWriter.writerow(data);
 
 print(' ');


### PR DESCRIPTION
Hey,

I've used your script and noticed some things that might be improved.
In one of my examples the scalar "global steps / sec" is slightly shorter than the first column.
in your version the script crashes with an index error, so I added some error handling (substituting the missing values with NaN)

I also noticed some typos in your readme, which I fixed.

Thanks for the script, it helped me a lot 